### PR TITLE
perf: use arrays for low branching runes

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 `go-useragent` is a high-performance Go library designed to parse browser name and version, operating system, and device type information from user-agent strings with _sub-microsecond_ parsing times.
 
-It achieves this efficiency by using a [trie](https://en.wikipedia.org/wiki/Trie) data structure to store and rapidly look up user-agent tokens. Utilizing heuristic rules, the library tokenizes a list of user-agent strings into a trie during startup. Subsequently, during runtime, the parsing process involves a straightforward lookup operation.
+It achieves this efficiency by using a modified hybrid [trie](https://en.wikipedia.org/wiki/Trie) data structure to store and rapidly look up user-agent tokens. Utilizing heuristic rules, the library tokenizes a list of user-agent strings into a trie during startup. Subsequently, during runtime, the parsing process involves a straightforward lookup operation.
 
 ## Installation
 

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -1,19 +1,19 @@
 # yaml-language-server: $schema=https://taskfile.dev/schema.json
-version: "3"
+version: '3'
 
 tasks:
   test:
     cmds:
       - go test ./... {{.CLI_ARGS}}
-  
+
   bench:
     cmds:
-      - go test -bench=. ./... 
-    
+      - go test -bench=. -benchmem ./...
+
   generate:
     cmds:
       - go run ./scripts/main.go
-  
+
   upgrade:
     cmds:
-      - go get -u ./... 
+      - go get -u ./...

--- a/bench_test.go
+++ b/bench_test.go
@@ -1,7 +1,6 @@
 package useragent_test
 
 import (
-	"strings"
 	"testing"
 
 	ua "github.com/medama-io/go-useragent"
@@ -12,14 +11,13 @@ var result ua.UserAgent
 func BenchmarkParserAll(b *testing.B) {
 	parser := ua.NewParser()
 
-	for _, k := range testCases {
-		name := strings.ReplaceAll(k, " ", "")
-		b.Run(name, func(b *testing.B) {
+	b.Run("All", func(b *testing.B) {
+		for _, k := range testCases {
 			for i := 0; i < b.N; i++ {
 				result = parser.Parse(k)
 			}
-		})
-	}
+		}
+	})
 }
 
 func BenchmarkParserSingle(b *testing.B) {
@@ -27,5 +25,19 @@ func BenchmarkParserSingle(b *testing.B) {
 
 	for i := 0; i < b.N; i++ {
 		result = parser.Parse(testCases[0])
+	}
+}
+
+func BenchmarkParserPutAll(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		ua.NewParser()
+	}
+}
+
+func BenchmarkParserPutSingle(b *testing.B) {
+	trie := ua.NewRuneTrie()
+
+	for i := 0; i < b.N; i++ {
+		trie.Put(testCases[0])
 	}
 }

--- a/ua.go
+++ b/ua.go
@@ -1,6 +1,8 @@
 package useragent
 
-import "strings"
+import (
+	"strings"
+)
 
 type Parser struct {
 	Trie *RuneTrie


### PR DESCRIPTION
This reduces the number of maps in the final trie structure by relying on arrays with a linear search for runes with less than 64 children. 

Old:
```
BenchmarkParserAll/All-16          61072             19564 ns/op             576 B/op         55 allocs/op
BenchmarkParserSingle-16         1996647               518.8 ns/op            31 B/op          2 allocs/op
BenchmarkParserPutAll-16              64          16484833 ns/op        15168293 B/op     248607 allocs/op
BenchmarkParserPutSingle-16       405416              2707 ns/op             448 B/op         12 allocs/op
```

New:
```
BenchmarkParserAll/All-16          69675             16349 ns/op             576 B/op         55 allocs/op
BenchmarkParserSingle-16         2621797               440.9 ns/op            26 B/op          2 allocs/op
BenchmarkParserPutAll-16              93          12369175 ns/op         7014044 B/op     176055 allocs/op
BenchmarkParserPutSingle-16       438016              2609 ns/op             448 B/op         12 allocs/op
```