### PR TITLE
perf: realign structs to reduce memory padding

### DIFF
--- a/match.go
+++ b/match.go
@@ -211,7 +211,7 @@ func MatchTokenIndexes(ua string) []MatchResults {
 // This adds a matching constant to a user agent struct.
 func (ua *UserAgent) addMatch(result Result) bool {
 	// Browsers
-	if result.Type == BrowserMatch && result.Precedence > ua.precedence.Browser {
+	if result.Type == BrowserMatch && result.Precedence > ua.BrowserPrecedence {
 		switch result.Match {
 		case Chrome:
 			ua.Browser = Chrome
@@ -238,12 +238,12 @@ func (ua *UserAgent) addMatch(result Result) bool {
 			ua.Browser = YandexBrowser
 		}
 
-		ua.precedence.Browser = result.Precedence
+		ua.BrowserPrecedence = result.Precedence
 		return true
 	}
 
 	// Operating Systems
-	if result.Type == OSMatch && result.Precedence > ua.precedence.OS {
+	if result.Type == OSMatch && result.Precedence > ua.OSPrecedence {
 		switch result.Match {
 		case Android:
 			ua.OS = Android
@@ -252,7 +252,7 @@ func (ua *UserAgent) addMatch(result Result) bool {
 				ua.Browser = AndroidBrowser
 				// Special case we set this as the precedence with this is zero
 				// and can be overwritten by Safari.
-				ua.precedence.Browser = matchPrecedenceMap[Mobile]
+				ua.BrowserPrecedence = matchPrecedenceMap[Mobile]
 			}
 		case ChromeOS:
 			ua.OS = ChromeOS
@@ -276,12 +276,12 @@ func (ua *UserAgent) addMatch(result Result) bool {
 			ua.Desktop = true
 		}
 
-		ua.precedence.OS = result.Precedence
+		ua.OSPrecedence = result.Precedence
 		return true
 	}
 
 	// Types
-	if result.Type == TypeMatch && result.Precedence > ua.precedence.Type {
+	if result.Type == TypeMatch && result.Precedence > ua.TypePrecedence {
 		switch result.Match {
 		case Desktop:
 			ua.Desktop = true
@@ -301,7 +301,7 @@ func (ua *UserAgent) addMatch(result Result) bool {
 			ua.Bot = true
 		}
 
-		ua.precedence.Type = result.Precedence
+		ua.TypePrecedence = result.Precedence
 		return true
 	}
 

--- a/trie.go
+++ b/trie.go
@@ -15,12 +15,13 @@ const (
 )
 
 type Result struct {
-	Match string
 	// 0: Unknown, 1: Browser, 2: OS, 3: Type
 	Type uint8
 	// Precedence value for each result type to determine which result
 	// should be overwritten.
 	Precedence uint8
+
+	Match string
 }
 
 type childNode struct {
@@ -50,9 +51,7 @@ func NewRuneTrie() *RuneTrie {
 // nodes or for nodes with a value of nil.
 func (trie *RuneTrie) Get(key string) UserAgent {
 	node := trie
-	ua := UserAgent{
-		precedence: Precedence{},
-	}
+	ua := UserAgent{}
 
 	// Flag to indicate if we are currently iterating over a version number.
 	var isVersion bool

--- a/ua.go
+++ b/ua.go
@@ -8,16 +8,14 @@ type Parser struct {
 	Trie *RuneTrie
 }
 
-// Precedence is the order in which the user agent matched the
-// browser, device, and OS. The lower the number, the higher the
-// precedence.
-type Precedence struct {
-	Browser uint8
-	OS      uint8
-	Type    uint8
-}
-
 type UserAgent struct {
+	// Precedence is the order in which the user agent matched the
+	// browser, device, and OS. The lower the number, the higher the
+	// precedence.
+	BrowserPrecedence uint8
+	OSPrecedence      uint8
+	TypePrecedence    uint8
+
 	Browser string
 	OS      string
 	Version string
@@ -27,8 +25,6 @@ type UserAgent struct {
 	Tablet  bool
 	TV      bool
 	Bot     bool
-
-	precedence Precedence
 }
 
 // Create a new Trie and populate it with user agent data.


### PR DESCRIPTION
Fun micro-optimisation that barely affects the performance but is interesting to me. Go structs behave like C where the *order* of struct elements matter, as the compiler will optimise memory access by padding and aligning the elements.

On average I saw around `10 ns/op` improvement for a single parse which is almost nothing, but it was a surprisingly consistent result on multiple runs.