### PR TITLE
fix: ensure android triggers is mobile flag

### DIFF
--- a/agents/4.txt
+++ b/agents/4.txt
@@ -2,3 +2,4 @@ Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Falkon/23
 Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Falkon/23.04.3 QtWebEngine/5.15.15 Chrome/87.0.4280.144 Safari/537.36
 Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Falkon/24.05.2 QtWebEngine/6.7.0 Chrome/118.0.5993.220 Safari/537.36
 Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Falkon/24.02.2 QtWebEngine/6.7.0 Chrome/118.0.5993.220 Safari/537.36
+Mozilla/5.0 (Android 13; Mobile; rv:123.0) Gecko/123.0 Firefox/123.0

--- a/internal/match_test.go
+++ b/internal/match_test.go
@@ -67,6 +67,9 @@ var matchResults = [][]string{
 
 	// Falkon (1)
 	{internal.Safari, internal.Chrome, internal.Falkon, internal.Linux},
+
+	// Android Firefox (1)
+	{internal.Firefox, internal.Mobile, internal.Android},
 }
 
 func TestMatchTokenIndexes(t *testing.T) {

--- a/internal/version_test.go
+++ b/internal/version_test.go
@@ -63,6 +63,8 @@ var versionResults = []string{
 
 	"MozillaiPhoneCPUiPhoneOSlikeMacOSXAppleWebKitKHTMLlikeGeckoMobile",
 	"MozillaXLinuxxAppleWebKitKHTMLlikeGeckoFalkonQtWebEngineChromeSafari",
+
+	"MozillaAndroidGeckoFirefox",
 }
 
 func TestCleanVersions(t *testing.T) {

--- a/testdata/cases.go
+++ b/testdata/cases.go
@@ -58,4 +58,7 @@ var TestCases = []string{
 
 	// Falkon
 	"Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Falkon/24.02.2 QtWebEngine/6.7.0 Chrome/118.0.5993.220 Safari/537.36",
+
+	// Android Firefox
+	"Mozilla/5.0 (Android 13; Mobile; rv:123.0) Gecko/123.0 Firefox/123.0",
 }

--- a/trie.go
+++ b/trie.go
@@ -283,6 +283,7 @@ func (ua *UserAgent) addMatch(result resultItem) bool {
 		switch result.Match {
 		case internal.Android:
 			ua.os = internal.Android
+			ua.mobile = true
 			// An older generic white-labeled variant of Chrome/Chromium on Android.
 			if ua.browser == "" {
 				ua.browser = internal.AndroidBrowser

--- a/ua_test.go
+++ b/ua_test.go
@@ -73,6 +73,8 @@ var resultCases = []ResultCase{
 	{Browser: internal.Safari, OS: internal.IOS, Mobile: true},
 	// Falkon (1) 37
 	{Browser: internal.Falkon, OS: internal.Linux, Desktop: true, Version: "24.02.2"},
+	// Android Firefox (1) 38
+	{Browser: internal.Firefox, OS: internal.Android, Mobile: true, Version: "123.0"},
 }
 
 func TestParse(t *testing.T) {


### PR DESCRIPTION
Closes #11. The mobile flag is removed if there are other signs indicating it is a tablet.