### PR TITLE
perf: use device uint8

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,10 @@
 name: Go
-on: [push, pull_request]
+on:
+  workflow_dispatch: ~
+  pull_request: ~
+  push:
+    branches:
+      - main
 
 jobs:
   build:
@@ -21,4 +26,3 @@ jobs:
 
       - name: Run Benchmarks
         run: go test -bench=. -benchmem ./...
-

--- a/.mise.toml
+++ b/.mise.toml
@@ -1,0 +1,3 @@
+[tools]
+go = "latest"
+gofumpt = "latest"

--- a/README.md
+++ b/README.md
@@ -22,39 +22,40 @@ This type of parser is typically initialized once at application startup and reu
 package main
 
 import (
-	"fmt"
-	"github.com/medama-io/go-useragent"
+    "fmt"
+    "github.com/medama-io/go-useragent"
 )
 
 func main() {
-	// Create a new parser. Initialize only once during application startup.
-	ua := useragent.NewParser()
+    // Create a new parser. Initialize only once during application startup.
+    ua := useragent.NewParser()
 
-	// Example user-agent string.
-	str := "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/118.0.0.0 Safari/537.36"
+    // Example user-agent string.
+    str := "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/118.0.0.0 Safari/537.36"
 
-	// Parse the user-agent string.
-	agent := ua.Parse(str)
+    // Parse the user-agent string.
+    agent := ua.Parse(str)
 
-	// Access parsed information using agent fields.
-	fmt.Println(agent.GetBrowser())  // Chrome
-	fmt.Println(agent.GetOS())       // Windows
-	fmt.Println(agent.GetVersion())  // 118.0.0.0
-	fmt.Println(agent.IsDesktop())  // true
-	fmt.Println(agent.IsMobile())   // false
-	fmt.Println(agent.IsTablet())   // false
-	fmt.Println(agent.IsTV())       // false
-	fmt.Println(agent.IsBot())      // false
+    // Access parsed information using agent fields.
+    fmt.Println(agent.GetBrowser())  // Chrome
+    fmt.Println(agent.GetOS())       // Windows
+    fmt.Println(agent.GetVersion())  // 118.0.0.0
+    fmt.Println(agent.IsDesktop())  // true
+    fmt.Println(agent.IsMobile())   // false
+    fmt.Println(agent.IsTablet())   // false
+    fmt.Println(agent.IsTV())       // false
+    fmt.Println(agent.IsBot())      // false
 
-	// Helper functions.
-	fmt.Println(agent.GetMajorVersion())  // 118
+    // Helper functions.
+    fmt.Println(agent.GetMajorVersion())  // 118
 }
 ```
+
 Refer to the [pkg.go.dev](https://pkg.go.dev/github.com/medama-io/go-useragent) documentation for more details on available fields and their meanings.
 
-## Benchmarks 
+## Benchmarks
 
-Benchmarks were performed against [`ua-parser/uap-go`](https://github.com/ua-parser/uap-go) and [`mileusena/useragent`](https://github.com/mileusna/useragent) on an AMD Ryzen 7 5800X 8 Core Processor. 
+Benchmarks were performed against [`ua-parser/uap-go`](https://github.com/ua-parser/uap-go) and [`mileusena/useragent`](https://github.com/mileusna/useragent) on an AMD Ryzen 7 5800X 8 Core Processor.
 
 ```bash
 cd ./benchmarks

--- a/benchmarks/go.mod
+++ b/benchmarks/go.mod
@@ -13,3 +13,5 @@ require (
 	github.com/hashicorp/golang-lru v0.5.4 // indirect
 	gopkg.in/yaml.v2 v2.2.1 // indirect
 )
+
+replace github.com/medama-io/go-useragent => ../

--- a/benchmarks/go.sum
+++ b/benchmarks/go.sum
@@ -4,8 +4,6 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/hashicorp/golang-lru v0.5.4 h1:YDjusn29QI/Das2iO9M0BHnIbxPeyuCHsjMW+lJfyTc=
 github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
-github.com/medama-io/go-useragent v0.0.0-20240905091033-b6ed64f91ed8 h1:TRDOdOQHwYdPM693skde2GQXAiXp1BUY/0KPVZOAhZ8=
-github.com/medama-io/go-useragent v0.0.0-20240905091033-b6ed64f91ed8/go.mod h1:H9GYWth4IN8vAFZh5LeARza7VwM4jK9uk7Tb9huVzLw=
 github.com/mileusna/useragent v1.3.4 h1:MiuRRuvGjEie1+yZHO88UBYg8YBC/ddF6T7F56i3PCk=
 github.com/mileusna/useragent v1.3.4/go.mod h1:3d8TOmwL/5I8pJjyVDteHtgDGcefrFUX4ccGOMKNYYc=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/helpers.go
+++ b/helpers.go
@@ -6,27 +6,27 @@ import (
 
 // IsDesktop returns true if the user agent is a desktop browser.
 func (ua UserAgent) IsDesktop() bool {
-	return ua.desktop
+	return ua.device == deviceDesktop
 }
 
 // IsMobile returns true if the user agent is a mobile browser.
 func (ua UserAgent) IsMobile() bool {
-	return ua.mobile
+	return ua.device == deviceMobile
 }
 
 // IsTablet returns true if the user agent is a tablet browser.
 func (ua UserAgent) IsTablet() bool {
-	return ua.tablet
+	return ua.device == deviceTablet
 }
 
 // IsTV returns true if the user agent is a TV browser.
 func (ua UserAgent) IsTV() bool {
-	return ua.tv
+	return ua.device == deviceTV
 }
 
 // IsBot returns true if the user agent is a bot.
 func (ua UserAgent) IsBot() bool {
-	return ua.bot
+	return ua.device == deviceBot
 }
 
 // GetBrowser returns the browser name. If no browser is found, it returns an empty string.

--- a/internal/match.go
+++ b/internal/match.go
@@ -143,8 +143,8 @@ var MatchPrecedenceMap = map[string]uint8{
 
 // MatchResults contains the information from MatchTokenIndexes.
 type MatchResults struct {
-	EndIndex int
 	Match    string
+	EndIndex int
 	// 0: Unknown, 1: Browser, 2: OS, 3: Type
 	MatchType uint8
 	// Precedence value for each result type to determine which result should be overwritten.

--- a/trie.go
+++ b/trie.go
@@ -17,18 +17,17 @@ const (
 )
 
 type resultItem struct {
+	Match string
 	// 0: Unknown, 1: Browser, 2: OS, 3: Type
 	Type uint8
 	// Precedence value for each result type to determine which result
 	// should be overwritten.
 	Precedence uint8
-
-	Match string
 }
 
 type childNode struct {
-	r    rune
 	node *RuneTrie
+	r    rune
 }
 
 // RuneTrie is a trie of runes with string keys and interface{} values.

--- a/trie.go
+++ b/trie.go
@@ -259,7 +259,7 @@ func (ua *UserAgent) addMatch(result resultItem) bool {
 			ua.browser = internal.Opera
 		case internal.OperaMini:
 			ua.browser = internal.OperaMini
-			ua.mobile = true
+			ua.device = deviceMobile
 		case internal.Safari:
 			ua.browser = internal.Safari
 		case internal.Vivaldi:
@@ -283,7 +283,7 @@ func (ua *UserAgent) addMatch(result resultItem) bool {
 		switch result.Match {
 		case internal.Android:
 			ua.os = internal.Android
-			ua.mobile = true
+			ua.device = deviceMobile
 			// An older generic white-labeled variant of Chrome/Chromium on Android.
 			if ua.browser == "" {
 				ua.browser = internal.AndroidBrowser
@@ -293,27 +293,27 @@ func (ua *UserAgent) addMatch(result resultItem) bool {
 			}
 		case internal.ChromeOS:
 			ua.os = internal.ChromeOS
-			ua.desktop = true
+			ua.device = deviceDesktop
 
 		case internal.IOS:
 			ua.os = internal.IOS
-			if !ua.tablet {
-				ua.mobile = true
+			if ua.device != deviceTablet {
+				ua.device = deviceMobile
 			}
 		case internal.Linux:
 			ua.os = internal.Linux
-			if !ua.tablet && !ua.tv {
-				ua.desktop = true
+			if ua.device != deviceTablet && ua.device != deviceTV {
+				ua.device = deviceDesktop
 			}
 		case internal.OpenBSD:
 			ua.os = internal.OpenBSD
-			ua.desktop = true
+			ua.device = deviceDesktop
 		case internal.MacOS:
 			ua.os = internal.MacOS
-			ua.desktop = true
+			ua.device = deviceDesktop
 		case internal.Windows:
 			ua.os = internal.Windows
-			ua.desktop = true
+			ua.device = deviceDesktop
 		}
 
 		ua.osPrecedence = result.Precedence
@@ -324,21 +324,17 @@ func (ua *UserAgent) addMatch(result resultItem) bool {
 	if result.Type == internal.TypeMatch && result.Precedence > ua.typePrecedence {
 		switch result.Match {
 		case internal.Desktop:
-			ua.desktop = true
+			ua.device = deviceDesktop
 		case internal.Tablet:
-			if ua.mobile {
-				ua.mobile = false
-			}
-			ua.tablet = true
+			ua.device = deviceTablet
 		case internal.Mobile, internal.MobileDevice:
-			if !ua.tablet {
-				ua.mobile = true
-				ua.desktop = false
+			if ua.device != deviceTablet {
+				ua.device = deviceMobile
 			}
 		case internal.TV:
-			ua.tv = true
+			ua.device = deviceTV
 		case internal.Bot:
-			ua.bot = true
+			ua.device = deviceBot
 		}
 
 		ua.typePrecedence = result.Precedence

--- a/ua.go
+++ b/ua.go
@@ -20,6 +20,10 @@ type Parser struct {
 }
 
 type UserAgent struct {
+	browser string
+	os      string
+	version string
+
 	// Precedence is the order in which the user agent matched the
 	// browser, device, and OS. The lower the number, the higher the
 	// precedence.
@@ -27,10 +31,7 @@ type UserAgent struct {
 	osPrecedence      uint8
 	typePrecedence    uint8
 
-	browser string
-	os      string
-	version string
-	device  device
+	device device
 }
 
 // Create a new Trie and populate it with user agent data.

--- a/ua.go
+++ b/ua.go
@@ -4,6 +4,17 @@ import (
 	"strings"
 )
 
+type device uint8
+
+const (
+	deviceUnknown device = iota
+	deviceDesktop
+	deviceMobile
+	deviceTablet
+	deviceTV
+	deviceBot
+)
+
 type Parser struct {
 	Trie *RuneTrie
 }
@@ -19,12 +30,7 @@ type UserAgent struct {
 	browser string
 	os      string
 	version string
-
-	desktop bool
-	mobile  bool
-	tablet  bool
-	tv      bool
-	bot     bool
+	device  device
 }
 
 // Create a new Trie and populate it with user agent data.

--- a/ua_test.go
+++ b/ua_test.go
@@ -66,7 +66,7 @@ var resultCases = []ResultCase{
 	{Bot: true},
 	{Bot: true},
 	{Bot: true, Browser: internal.Chrome, Version: "112.0.0.0"},
-	{Bot: true, Browser: internal.Chrome, OS: internal.Linux, Version: "125.0.6422.76", Desktop: true},
+	{Bot: true, Browser: internal.Chrome, OS: internal.Linux, Version: "125.0.6422.76"},
 	// Yandex Browser (1) 35
 	{Browser: internal.YandexBrowser, OS: internal.Android, Mobile: true, Version: "24.1.7.27.00"},
 	// Safari UIWebView (1) 36


### PR DESCRIPTION
To reduce the total byte size of the `UserAgent` struct, this uses a `uint8` field for a "device" instead of 5 separate bools. I don't think it actually makes a difference but the ergonomics of it is a little nicer for future plans.

I also ran `[betteralign`](https://github.com/dkorunic/betteralign) on the repo for minor improvements.

