### PR TITLE
feat: expose constants in a new agents lib

### DIFF
--- a/agents/const.go
+++ b/agents/const.go
@@ -1,0 +1,52 @@
+package agents
+
+type (
+	// Browser represents a browser name.
+	Browser string
+	// OS represents an operating system name.
+	OS string
+	// Device represents a device type.
+	Device string
+)
+
+const (
+	BrowserAndroid   Browser = "Android Browser"
+	BrowserChrome    Browser = "Chrome"
+	BrowserEdge      Browser = "Edge"
+	BrowserFirefox   Browser = "Firefox"
+	BrowserIE        Browser = "IE"
+	BrowserOpera     Browser = "pera"
+	BrowserOperaMini Browser = "Mini"
+	BrowserSafari    Browser = "Safari"
+	BrowserVivaldi   Browser = "Vivaldi"
+	BrowserSamsung   Browser = "Samsung Browser"
+	BrowserFalkon    Browser = "Falkon"
+	BrowserNintendo  Browser = "Nintendo Browser"
+	BrowserYandex    Browser = "Yandex Browser"
+
+	OSAndroid  OS = "Android"
+	OSChromeOS OS = "ChromeOS"
+	OSIOS      OS = "iOS"
+	OSLinux    OS = "Linux"
+	OSOpenBSD  OS = "OpenBSD"
+	OSMacOS    OS = "MacOS"
+	OSWindows  OS = "Windows"
+
+	DeviceDesktop Device = "Desktop"
+	DeviceMobile  Device = "Mobile"
+	DeviceTablet  Device = "Tablet"
+	DeviceTV      Device = "TV"
+	DeviceBot     Device = "Bot"
+)
+
+func (b Browser) String() string {
+	return string(b)
+}
+
+func (o OS) String() string {
+	return string(o)
+}
+
+func (d Device) String() string {
+	return string(d)
+}

--- a/helpers.go
+++ b/helpers.go
@@ -3,25 +3,72 @@ package useragent
 import (
 	"strings"
 
+	"github.com/medama-io/go-useragent/agents"
 	"github.com/medama-io/go-useragent/internal"
 )
 
-// GetDevice returns the device type as a string.
-func (ua UserAgent) GetDevice() string {
-	switch ua.device {
-	case internal.DeviceDesktop:
-		return internal.Desktop
-	case internal.DeviceMobile:
-		return internal.Mobile
-	case internal.DeviceTablet:
-		return internal.Tablet
-	case internal.DeviceTV:
-		return internal.TV
-	case internal.DeviceBot:
-		return internal.Bot
-	default:
-		return internal.Unknown
+// Browser returns the browser name. If no browser is found, it returns an empty string.
+func (ua UserAgent) Browser() agents.Browser {
+	return ua.browser.GetMatchBrowser()
+}
+
+// OS returns the operating system name. If no OS is found, it returns an empty string.
+func (ua UserAgent) OS() agents.OS {
+	return ua.os.GetMatchOS()
+}
+
+// Device returns the device type as a string.
+func (ua UserAgent) Device() agents.Device {
+	return ua.device.GetMatchDevice()
+}
+
+// BrowserVersion returns the browser version. If no version is found, it returns an empty string.
+func (ua UserAgent) BrowserVersion() string {
+	return string(ua.version[:ua.versionIndex])
+}
+
+// BrowserVersionMajor returns the major version of the browser. If no version is found, it returns an empty string.
+func (ua UserAgent) BrowserVersionMajor() string {
+	if ua.versionIndex == 0 {
+		return ""
 	}
+
+	version := ua.BrowserVersion()
+
+	return strings.Split(version, ".")[0]
+}
+
+// BrowserVersionMinor returns the minor version of the browser. If no version is found, it returns an empty string.
+func (ua UserAgent) BrowserVersionMinor() string {
+	if ua.versionIndex == 0 {
+		return ""
+	}
+
+	version := ua.BrowserVersion()
+
+	parts := strings.Split(version, ".")
+	if len(parts) < 2 {
+		return ""
+	}
+
+	return parts[1]
+}
+
+// BrowserVersionPatch returns the patch version of the browser. If no version is found, it returns an empty string.
+func (ua UserAgent) BrowserVersionPatch() string {
+	if ua.versionIndex == 0 {
+		return ""
+	}
+
+	version := ua.BrowserVersion()
+
+	parts := strings.Split(version, ".")
+	if len(parts) < 3 {
+		return ""
+	}
+
+	// Sometimes the patch version has a suffix, e.g. "1.2.3b".
+	return strings.Join(parts[2:], ".")
 }
 
 // IsDesktop returns true if the user agent is a desktop browser.
@@ -50,27 +97,36 @@ func (ua UserAgent) IsBot() bool {
 }
 
 // GetBrowser returns the browser name. If no browser is found, it returns an empty string.
+//
+// Deprecated: Use .Browser() instead.
 func (ua UserAgent) GetBrowser() string {
-	return ua.browser
+	return string(ua.browser.GetMatchBrowser())
 }
 
 // GetOS returns the operating system name. If no OS is found, it returns an empty string.
+//
+// Deprecated: Use .OS() instead.
 func (ua UserAgent) GetOS() string {
-	return ua.os
+	return string(ua.os.GetMatchOS())
+}
+
+// GetDevice returns the device type as a string.
+//
+// Deprecated: Use .Device() instead.
+func (ua UserAgent) GetDevice() string {
+	return string(ua.device.GetMatchDevice())
 }
 
 // GetVersion returns the browser version. If no version is found, it returns an empty string.
+//
+// Deprecated: Use .BrowserVersion() instead.
 func (ua UserAgent) GetVersion() string {
-	return string(ua.version[:ua.versionIndex])
+	return ua.BrowserVersion()
 }
 
 // GetMajorVersion returns the major version of the browser. If no version is found, it returns an empty string.
+//
+// Deprecated: Use .BrowserVersionMajor() instead.
 func (ua UserAgent) GetMajorVersion() string {
-	if ua.versionIndex == 0 {
-		return ""
-	}
-
-	version := string(ua.version[:ua.versionIndex])
-
-	return strings.Split(version, ".")[0]
+	return ua.BrowserVersionMajor()
 }

--- a/internal/const.go
+++ b/internal/const.go
@@ -1,23 +1,195 @@
 package internal
 
+import "github.com/medama-io/go-useragent/agents"
+
 type (
-	// Match is an enum for the match type.
+	// Match is an enum for the browser, os or device name.
 	Match uint8
-	// Device is an enum for the device type.
-	Device uint8
+	// MatchType is an enum for the match type.
+	MatchType uint8
 )
 
 const (
-	MatchUnknown Match = iota
-	MatchBrowser
-	MatchOS
-	MatchType
-	MatchVersion
+	Unknown Match = iota
 
-	DeviceUnknown Device = iota
+	// There is no match token for Android Browser, but the absence of any browser token paired with Android is a good indicator of this browser.
+	BrowserAndroid
+	BrowserChrome
+	BrowserEdge
+	BrowserFirefox
+	BrowserIE
+	BrowserOpera
+	BrowserOperaMini
+	BrowserSafari
+	BrowserVivaldi
+	BrowserSamsung
+	BrowserFalkon
+	BrowserNintendo
+	BrowserYandex
+
+	OSAndroid
+	OSChromeOS
+	OSIOS
+	OSLinux
+	OSOpenBSD
+	OSMacOS
+	OSWindows
+
 	DeviceDesktop
 	DeviceMobile
 	DeviceTablet
 	DeviceTV
 	DeviceBot
+
+	TokenVersion
+	// We need a separate type for mobile devices since some user agents use "Mobile/"
+	// appended with a device ID. We need to handle these separately to strip those IDs
+	// out.
+	TokenMobileDevice
+
+	MatchUnknown MatchType = iota
+	MatchBrowser
+	MatchOS
+	MatchDevice
+	MatchVersion
 )
+
+// GetMatchType returns the match type of a match result using the MatchPrecedenceMap.
+func (m Match) GetMatchType() MatchType {
+	switch m {
+	case BrowserAndroid,
+		BrowserChrome,
+		BrowserEdge,
+		BrowserFirefox,
+		BrowserIE,
+		BrowserOpera,
+		BrowserOperaMini,
+		BrowserSafari,
+		BrowserVivaldi,
+		BrowserSamsung,
+		BrowserFalkon,
+		BrowserNintendo,
+		BrowserYandex:
+		return MatchBrowser
+
+	case OSAndroid,
+		OSChromeOS,
+		OSIOS,
+		OSLinux,
+		OSOpenBSD,
+		OSMacOS,
+		OSWindows:
+		return MatchOS
+
+	case DeviceDesktop,
+		DeviceMobile,
+		DeviceTablet,
+		DeviceTV,
+		DeviceBot,
+		TokenMobileDevice:
+		return MatchDevice
+
+	case TokenVersion:
+		return MatchVersion
+	}
+
+	return MatchUnknown
+}
+
+// GetMatchBrowser returns the browser name of a match.
+func (m Match) GetMatchBrowser() agents.Browser {
+	switch m {
+	case BrowserAndroid:
+		return agents.BrowserAndroid
+	case BrowserChrome:
+		return agents.BrowserChrome
+	case BrowserEdge:
+		return agents.BrowserEdge
+	case BrowserFirefox:
+		return agents.BrowserFirefox
+	case BrowserIE:
+		return agents.BrowserIE
+	case BrowserOpera:
+		return agents.BrowserOpera
+	case BrowserOperaMini:
+		return agents.BrowserOperaMini
+	case BrowserSafari:
+		return agents.BrowserSafari
+	case BrowserVivaldi:
+		return agents.BrowserVivaldi
+	case BrowserSamsung:
+		return agents.BrowserSamsung
+	case BrowserFalkon:
+		return agents.BrowserFalkon
+	case BrowserNintendo:
+		return agents.BrowserNintendo
+	case BrowserYandex:
+		return agents.BrowserYandex
+	}
+
+	return ""
+}
+
+// GetMatchOS returns the OS name of a match.
+func (m Match) GetMatchOS() agents.OS {
+	switch m {
+	case OSAndroid:
+		return agents.OSAndroid
+	case OSChromeOS:
+		return agents.OSChromeOS
+	case OSIOS:
+		return agents.OSIOS
+	case OSLinux:
+		return agents.OSLinux
+	case OSOpenBSD:
+		return agents.OSOpenBSD
+	case OSMacOS:
+		return agents.OSMacOS
+	case OSWindows:
+		return agents.OSWindows
+	}
+
+	return ""
+}
+
+// GetMatchDevice returns the device name of a match.
+func (m Match) GetMatchDevice() agents.Device {
+	switch m {
+	case DeviceDesktop:
+		return agents.DeviceDesktop
+	case DeviceMobile:
+		return agents.DeviceMobile
+	case DeviceTablet:
+		return agents.DeviceTablet
+	case DeviceTV:
+		return agents.DeviceTV
+	case DeviceBot:
+		return agents.DeviceBot
+	}
+
+	return ""
+}
+
+// GetMatchName returns the name of a match. This is used for debugging in tests.
+func (m Match) GetMatchName() string {
+	if browser := m.GetMatchBrowser(); browser != "" {
+		return browser.String()
+	}
+
+	if os := m.GetMatchOS(); os != "" {
+		return os.String()
+	}
+
+	if device := m.GetMatchDevice(); device != "" {
+		return device.String()
+	}
+
+	switch m {
+	case TokenVersion:
+		return "Version"
+	case TokenMobileDevice:
+		return "MobileDevice"
+	}
+
+	return ""
+}

--- a/internal/match.go
+++ b/internal/match.go
@@ -4,48 +4,7 @@ import (
 	"sort"
 
 	str "github.com/boyter/go-string"
-)
-
-// Browsers.
-const (
-	// There is no match token for this, but the absence of any browser token paired with Android is a good indicator of this browser.
-	AndroidBrowser = "Android Browser"
-	Chrome         = "Chrome"
-	Edge           = "Edge"
-	Firefox        = "Firefox"
-	IE             = "IE"
-	Opera          = "Opera"
-	OperaMini      = "Mini"
-	Safari         = "Safari"
-	Vivaldi        = "Vivaldi"
-	Samsung        = "Samsung Browser"
-	Falkon         = "Falkon"
-	Nintendo       = "Nintendo Browser"
-	YandexBrowser  = "Yandex Browser"
-
-	// Operating Systems.
-	Android  = "Android"
-	ChromeOS = "ChromeOS"
-	IOS      = "iOS"
-	Linux    = "Linux"
-	OpenBSD  = "OpenBSD"
-	MacOS    = "MacOS"
-	Windows  = "Windows"
-
-	// Types.
-	Desktop = "Desktop"
-	Mobile  = "Mobile"
-	// We need a separate type for mobile devices since some user agents use "Mobile/"
-	// appended with a device ID. We need to handle these separately to strip those IDs
-	// out.
-	MobileDevice = "MobileDevice"
-	Tablet       = "Tablet"
-	TV           = "TV"
-	Bot          = "Bot"
-
-	// Version.
-	Version = "Version"
-	Unknown = "Unknown"
+	"github.com/medama-io/go-useragent/agents"
 )
 
 // matchMap is a map of user agent types to their matching strings.
@@ -53,40 +12,40 @@ const (
 //
 // Matching tokens are ordered by precedence. The first match is the
 // most important match.
-var matchMap = map[string][]string{
+var matchMap = map[Match][]string{
 	// Browsers
-	Chrome:        {"CriOS", Chrome},
-	Edge:          {"EdgiOS", Edge, "Edg"},
-	Firefox:       {"FxiOS", Firefox},
-	IE:            {"MSIE", "Trident"},
-	Opera:         {"OPiOS", "OPR", Opera},
-	OperaMini:     {OperaMini},
-	Safari:        {Safari, "AppleWebKit"},
-	Vivaldi:       {Vivaldi},
-	Samsung:       {"SamsungBrowser"},
-	Falkon:        {Falkon},
-	Nintendo:      {"NintendoBrowser"},
-	YandexBrowser: {"YaBrowser"},
+	BrowserChrome:    {"CriOS", string(agents.BrowserChrome)},
+	BrowserEdge:      {"EdgiOS", string(agents.BrowserEdge), "Edg"},
+	BrowserFirefox:   {"FxiOS", string(agents.BrowserFirefox)},
+	BrowserIE:        {"MSIE", "Trident"},
+	BrowserOpera:     {"OPiOS", "OPR", string(agents.BrowserOpera)},
+	BrowserOperaMini: {string(agents.BrowserOperaMini)},
+	BrowserSafari:    {string(agents.BrowserSafari), "AppleWebKit"},
+	BrowserVivaldi:   {string(agents.BrowserVivaldi)},
+	BrowserSamsung:   {"SamsungBrowser"},
+	BrowserFalkon:    {string(agents.BrowserFalkon)},
+	BrowserNintendo:  {"NintendoBrowser"},
+	BrowserYandex:    {"YaBrowser"},
 
 	// Operating Systems
-	Android:  {Android},
-	ChromeOS: {"CrOS"},
-	IOS:      {"iPhone", "iPad", "iPod"},
-	Linux:    {Linux, "Ubuntu", "Fedora"},
-	OpenBSD:  {OpenBSD},
-	MacOS:    {"Macintosh"},
-	Windows:  {"Windows NT", "WindowsNT"},
+	OSAndroid:  {string(agents.OSAndroid)},
+	OSChromeOS: {"CrOS"},
+	OSIOS:      {"iPhone", "iPad", "iPod"},
+	OSLinux:    {string(agents.OSLinux), "Ubuntu", "Fedora"},
+	OSOpenBSD:  {string(agents.OSOpenBSD)},
+	OSMacOS:    {"Macintosh"},
+	OSWindows:  {"Windows NT", "WindowsNT"},
 
-	// Types
-	Desktop:      {Desktop, "Ubuntu", "Fedora"},
-	Mobile:       {Mobile},
-	MobileDevice: {"ONEPLUS", "Huawei", "HTC", "Galaxy", "iPhone", "iPod", "Windows Phone", "WindowsPhone", "LG"},
-	Tablet:       {Tablet, "Touch", "iPad", "Nintendo Switch", "NintendoSwitch", "Kindle"},
-	TV:           {TV, "Large Screen", "LargeScreen", "Smart Display", "SmartDisplay", "PLAYSTATION", "PlayStation", "ADT-2", "ADT-1", "CrKey", "Roku", "AFT", "Web0S", "Nexus Player", "Xbox", "XBOX", "Nintendo WiiU", "NintendoWiiU"},
-	Bot:          {Bot, "HeadlessChrome", "bot", "Slurp", "LinkCheck", "QuickLook", "Haosou", "Yahoo Ad", "YahooAd", "Google", "Mediapartners", "Headless", "facebookexternalhit", "facebookcatalog", "Baidu", "Instagram", "Pinterest", "PageSpeedInsights", "WhatsApp"},
+	// Devices
+	DeviceDesktop:     {string(agents.DeviceDesktop), "Ubuntu", "Fedora"},
+	DeviceMobile:      {string(agents.DeviceMobile)},
+	TokenMobileDevice: {"ONEPLUS", "Huawei", "HTC", "Galaxy", "iPhone", "iPod", "Windows Phone", "WindowsPhone", "LG"},
+	DeviceTablet:      {string(agents.DeviceTablet), "Touch", "iPad", "Nintendo Switch", "NintendoSwitch", "Kindle"},
+	DeviceTV:          {string(agents.DeviceTV), "Large Screen", "LargeScreen", "Smart Display", "SmartDisplay", "PLAYSTATION", "PlayStation", "ADT-2", "ADT-1", "CrKey", "Roku", "AFT", "Web0S", "Nexus Player", "Xbox", "XBOX", "Nintendo WiiU", "NintendoWiiU"},
+	DeviceBot:         {string(agents.DeviceBot), "HeadlessChrome", "bot", "Slurp", "LinkCheck", "QuickLook", "Haosou", "Yahoo Ad", "YahooAd", "Google", "Mediapartners", "Headless", "facebookexternalhit", "facebookcatalog", "Baidu", "Instagram", "Pinterest", "PageSpeedInsights", "WhatsApp"},
 
 	// Version
-	Version: {Version},
+	TokenVersion: {"Version"},
 }
 
 // MatchPrecedenceMap is a map of user agent types to their importance
@@ -99,64 +58,50 @@ var matchMap = map[string][]string{
 //
 // By setting a precedence, we can determine which match is more important
 // and use that as the final result.
-var MatchPrecedenceMap = map[string]uint8{
+var MatchPrecedenceMap = map[Match]uint8{
 	// Browsers
-	Safari:         1, // Is always at the end of a Chrome user agent.
-	AndroidBrowser: 2,
-	Chrome:         3,
-	Firefox:        4,
-	IE:             5,
-	Opera:          6,
-	OperaMini:      7,
-	Edge:           8,
-	Vivaldi:        9,
-	Samsung:        10,
-	Falkon:         11,
-	Nintendo:       12,
-	YandexBrowser:  13,
+	BrowserSafari:    1, // Is always at the end of a Chrome user agent.
+	BrowserAndroid:   2,
+	BrowserChrome:    3,
+	BrowserFirefox:   4,
+	BrowserIE:        5,
+	BrowserOpera:     6,
+	BrowserOperaMini: 7,
+	BrowserEdge:      8,
+	BrowserVivaldi:   9,
+	BrowserSamsung:   10,
+	BrowserFalkon:    11,
+	BrowserNintendo:  12,
+	BrowserYandex:    13,
 
 	// Operating Systems
-	Linux:    1,
-	Android:  2,
-	IOS:      3,
-	OpenBSD:  4,
-	ChromeOS: 5,
-	MacOS:    6,
-	Windows:  7,
+	OSLinux:    1,
+	OSAndroid:  2,
+	OSIOS:      3,
+	OSOpenBSD:  4,
+	OSChromeOS: 5,
+	OSMacOS:    6,
+	OSWindows:  7,
 
 	// Types
-	Desktop:      1,
-	Mobile:       2,
-	MobileDevice: 3,
-	Tablet:       4,
-	TV:           5,
-	Bot:          6,
+	DeviceDesktop:     1,
+	DeviceMobile:      2,
+	TokenMobileDevice: 3,
+	DeviceTablet:      4,
+	DeviceTV:          5,
+	DeviceBot:         6,
 }
 
 // MatchResults contains the information from MatchTokenIndexes.
 type MatchResults struct {
-	Match     string
-	EndIndex  int
-	MatchType Match
+	Match     Match
+	MatchType MatchType
+
 	// Precedence value for each result type to determine which result should be overwritten.
 	// Higher values overwrite lower values.
 	Precedence uint8
-}
 
-// GetMatchType returns the match type of a match result using the MatchPrecedenceMap.
-func GetMatchType(match string) Match {
-	switch match {
-	case Chrome, Edge, Firefox, IE, Opera, OperaMini, Safari, Vivaldi, Samsung, Falkon, Nintendo, YandexBrowser:
-		return MatchBrowser
-	case Android, ChromeOS, IOS, Linux, OpenBSD, MacOS, Windows:
-		return MatchOS
-	case Desktop, Mobile, MobileDevice, Tablet, Bot, TV:
-		return MatchType
-	case Version:
-		return MatchVersion
-	default:
-		return MatchUnknown
-	}
+	EndIndex int
 }
 
 // MatchTokenIndexes finds the start and end indexes of necessary tokens
@@ -164,7 +109,7 @@ func GetMatchType(match string) Match {
 // when to insert a result value into the trie.
 func MatchTokenIndexes(ua string) []MatchResults {
 	var results []MatchResults
-	exists := make(map[string]bool)
+	exists := make(map[Match]bool)
 	for key, match := range matchMap {
 		for _, m := range match {
 			// Check if key match doesn't already exist in results.
@@ -183,7 +128,7 @@ func MatchTokenIndexes(ua string) []MatchResults {
 			lastIndex := indexes[len(indexes)-1]
 
 			// Add the match to the results.
-			matchType := GetMatchType(key)
+			matchType := key.GetMatchType()
 			results = append(results, MatchResults{EndIndex: lastIndex[1], Match: key, MatchType: matchType, Precedence: MatchPrecedenceMap[key]})
 			exists[key] = true
 		}

--- a/internal/match_test.go
+++ b/internal/match_test.go
@@ -9,78 +9,78 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-var matchResults = [][]string{
+var matchResults = [][]internal.Match{
 	// Windows (7)
-	{internal.Safari, internal.Chrome, internal.Windows},
-	{internal.Safari, internal.Chrome, internal.Windows},
-	{internal.Windows, internal.IE},
-	{internal.Windows, internal.IE},
-	{internal.IE, internal.Windows},
-	{internal.Windows, internal.IE},
-	{internal.Edge, internal.Safari, internal.Chrome, internal.Windows},
+	{internal.BrowserSafari, internal.BrowserChrome, internal.OSWindows},
+	{internal.BrowserSafari, internal.BrowserChrome, internal.OSWindows},
+	{internal.OSWindows, internal.BrowserIE},
+	{internal.OSWindows, internal.BrowserIE},
+	{internal.BrowserIE, internal.OSWindows},
+	{internal.OSWindows, internal.BrowserIE},
+	{internal.BrowserEdge, internal.BrowserSafari, internal.BrowserChrome, internal.OSWindows},
 
 	// Mac (5)
-	{internal.Safari, internal.Version, internal.MacOS},
-	{internal.Safari, internal.Chrome, internal.MacOS},
-	{internal.Firefox, internal.MacOS},
-	{internal.Vivaldi, internal.Safari, internal.Chrome, internal.MacOS},
-	{internal.Edge, internal.Safari, internal.Chrome, internal.MacOS},
+	{internal.BrowserSafari, internal.TokenVersion, internal.OSMacOS},
+	{internal.BrowserSafari, internal.BrowserChrome, internal.OSMacOS},
+	{internal.BrowserFirefox, internal.OSMacOS},
+	{internal.BrowserVivaldi, internal.BrowserSafari, internal.BrowserChrome, internal.OSMacOS},
+	{internal.BrowserEdge, internal.BrowserSafari, internal.BrowserChrome, internal.OSMacOS},
 
 	// Linux (5)
-	{internal.Firefox, internal.Linux},
-	{internal.Firefox, internal.Linux},
-	{internal.Firefox, internal.Linux, internal.Desktop},
-	{internal.Firefox, internal.Linux, internal.Desktop},
-	{internal.Safari, internal.Chrome, internal.Linux},
+	{internal.BrowserFirefox, internal.OSLinux},
+	{internal.BrowserFirefox, internal.OSLinux},
+	{internal.BrowserFirefox, internal.OSLinux, internal.DeviceDesktop},
+	{internal.BrowserFirefox, internal.OSLinux, internal.DeviceDesktop},
+	{internal.BrowserSafari, internal.BrowserChrome, internal.OSLinux},
 
 	// iPhone (5)
-	{internal.Safari, internal.Mobile, internal.Version, internal.MobileDevice, internal.IOS},
-	{internal.Safari, internal.Mobile, internal.Chrome, internal.MobileDevice, internal.IOS},
-	{internal.Safari, internal.Mobile, internal.Opera, internal.MobileDevice, internal.IOS},
-	{internal.Safari, internal.Mobile, internal.Firefox, internal.MobileDevice, internal.IOS},
-	{internal.Safari, internal.Mobile, internal.Edge, internal.Version, internal.MobileDevice, internal.IOS},
+	{internal.BrowserSafari, internal.DeviceMobile, internal.TokenVersion, internal.OSIOS, internal.TokenMobileDevice},
+	{internal.BrowserSafari, internal.DeviceMobile, internal.BrowserChrome, internal.OSIOS, internal.TokenMobileDevice},
+	{internal.BrowserSafari, internal.DeviceMobile, internal.BrowserOpera, internal.OSIOS, internal.TokenMobileDevice},
+	{internal.BrowserSafari, internal.DeviceMobile, internal.BrowserFirefox, internal.OSIOS, internal.TokenMobileDevice},
+	{internal.BrowserSafari, internal.DeviceMobile, internal.BrowserEdge, internal.TokenVersion, internal.OSIOS, internal.TokenMobileDevice},
 
 	// iPad (3)
-	{internal.Safari, internal.Mobile, internal.Version, internal.Tablet, internal.IOS},
-	{internal.Safari, internal.Mobile, internal.Chrome, internal.Tablet, internal.IOS},
-	{internal.Safari, internal.Mobile, internal.Firefox, internal.Tablet, internal.IOS},
+	{internal.BrowserSafari, internal.DeviceMobile, internal.TokenVersion, internal.OSIOS, internal.DeviceTablet},
+	{internal.BrowserSafari, internal.DeviceMobile, internal.BrowserChrome, internal.OSIOS, internal.DeviceTablet},
+	{internal.BrowserSafari, internal.DeviceMobile, internal.BrowserFirefox, internal.OSIOS, internal.DeviceTablet},
 
 	// Android (4)
-	{internal.Safari, internal.Mobile, internal.Chrome, internal.Samsung, internal.Android, internal.Linux},
-	{internal.Safari, internal.Mobile, internal.Version, internal.Android, internal.Linux},
-	{internal.Safari, internal.Mobile, internal.Version, internal.Android, internal.Linux},
-	{internal.Safari, internal.Mobile, internal.Chrome, internal.Version, internal.MobileDevice, internal.Android, internal.Linux},
-	{internal.Safari, internal.Mobile, internal.Chrome, internal.Android, internal.Linux},
+	{internal.BrowserSafari, internal.DeviceMobile, internal.BrowserChrome, internal.BrowserSamsung, internal.OSAndroid, internal.OSLinux},
+	{internal.BrowserSafari, internal.DeviceMobile, internal.TokenVersion, internal.OSAndroid, internal.OSLinux},
+	{internal.BrowserSafari, internal.DeviceMobile, internal.TokenVersion, internal.OSAndroid, internal.OSLinux},
+	{internal.BrowserSafari, internal.DeviceMobile, internal.BrowserChrome, internal.TokenVersion, internal.TokenMobileDevice, internal.OSAndroid, internal.OSLinux},
+	{internal.BrowserSafari, internal.DeviceMobile, internal.BrowserChrome, internal.OSAndroid, internal.OSLinux},
 
 	// Bots (4)
-	{internal.Bot},
-	{internal.Bot},
-	{internal.Bot},
-	{internal.Bot},
-	{internal.Safari, internal.Chrome, internal.Bot},
-	{internal.Safari, internal.Bot, internal.Chrome, internal.Linux},
+	{internal.DeviceBot},
+	{internal.DeviceBot},
+	{internal.DeviceBot},
+	{internal.DeviceBot},
+	{internal.BrowserSafari, internal.BrowserChrome, internal.DeviceBot},
+	{internal.BrowserSafari, internal.BrowserChrome, internal.DeviceBot, internal.OSLinux},
 
 	// Yandex Browser (1)
-	{internal.Safari, internal.Mobile, internal.YandexBrowser, internal.Chrome, internal.Android, internal.Linux},
+	{internal.BrowserSafari, internal.DeviceMobile, internal.BrowserYandex, internal.BrowserChrome, internal.OSAndroid, internal.OSLinux},
 
 	// Safari UIWebView (1)
-	{internal.Mobile, internal.Safari, internal.MobileDevice, internal.IOS},
+	{internal.DeviceMobile, internal.BrowserSafari, internal.OSIOS, internal.TokenMobileDevice},
 
 	// Falkon (1)
-	{internal.Safari, internal.Chrome, internal.Falkon, internal.Linux},
+	{internal.BrowserSafari, internal.BrowserChrome, internal.BrowserFalkon, internal.OSLinux},
 
 	// Android Firefox (1)
-	{internal.Firefox, internal.Mobile, internal.Android},
+	{internal.BrowserFirefox, internal.DeviceMobile, internal.OSAndroid},
 
 	// Linux ARM Architecture (1)
-	{internal.Safari, internal.Chrome, internal.Linux},
+	{internal.BrowserSafari, internal.BrowserChrome, internal.OSLinux},
 
 	// Samsung Browser
-	{internal.Safari, internal.TV, internal.Chrome, internal.Samsung, internal.Linux},
-	{internal.Safari, internal.Chrome, internal.Samsung, internal.Linux},
+	{internal.BrowserSafari, internal.DeviceTV, internal.BrowserChrome, internal.BrowserSamsung, internal.OSLinux},
+	{internal.BrowserSafari, internal.BrowserChrome, internal.BrowserSamsung, internal.OSLinux},
 
 	// OpenBSD
-	{internal.Firefox, internal.OpenBSD},
+	{internal.BrowserFirefox, internal.OSOpenBSD},
 }
 
 func TestMatchTokenIndexes(t *testing.T) {
@@ -94,7 +94,18 @@ func TestMatchTokenIndexes(t *testing.T) {
 			}
 
 			for j, m := range match {
-				assert.Equal(t, matchResults[i][j], m.Match, "Test Case: %s\nMatch Number: %d\nExpected: %v\nGot: %v", v, i, matchResults[i], match)
+				expected := []string{}
+				got := []string{}
+
+				for _, e := range matchResults[i] {
+					expected = append(expected, e.GetMatchName())
+				}
+
+				for _, g := range match {
+					got = append(got, g.Match.GetMatchName())
+				}
+
+				assert.Equal(t, matchResults[i][j], m.Match, "Test Case: %s\nMatch Number: %d\nExpected: %v\nGot: %v", v, i, expected, got)
 			}
 		})
 	}

--- a/internal/version.go
+++ b/internal/version.go
@@ -67,7 +67,7 @@ func RemoveMobileIdentifiers(ua string) string {
 	for _, token := range tokens {
 		var skipUntilWhitespace bool
 		var indexesToReplace []int
-		if token.Match == Mobile {
+		if token.Match == DeviceMobile {
 			// Iterate over the user agent string and remove all characters
 			// after the mobile token until we encounter whitespace.
 			for i, r := range ua {
@@ -103,7 +103,7 @@ func RemoveAndroidIdentifiers(ua string) string {
 		var skipUntilClosingParenthesis int
 		var indexesToReplace []int
 
-		if token.Match == Android {
+		if token.Match == OSAndroid {
 			// Iterate over the user agent string and remove all characters
 			// after the Android token until we encounter a closing parenthesis
 			// to remove device identifiers.

--- a/ua.go
+++ b/ua.go
@@ -17,11 +17,12 @@ type Parser struct {
 }
 
 type UserAgent struct {
-	browser string
-	os      string
-
 	version      [32]rune
 	versionIndex int
+
+	browser internal.Match
+	os      internal.Match
+	device  internal.Match
 
 	// Precedence is the order in which the user agent matched the
 	// browser, device, and OS. The lower the number, the higher the
@@ -29,8 +30,6 @@ type UserAgent struct {
 	browserPrecedence uint8
 	osPrecedence      uint8
 	typePrecedence    uint8
-
-	device internal.Device
 }
 
 // Create a new Trie and populate it with user agent data.

--- a/ua_test.go
+++ b/ua_test.go
@@ -6,83 +6,78 @@ import (
 
 	ua "github.com/medama-io/go-useragent"
 
-	"github.com/medama-io/go-useragent/internal"
+	"github.com/medama-io/go-useragent/agents"
 	"github.com/medama-io/go-useragent/testdata"
 	"github.com/stretchr/testify/assert"
 )
 
 type ResultCase struct {
-	Browser string
-	OS      string
+	Browser agents.Browser
+	OS      agents.OS
+	Device  agents.Device
 	Version string
-
-	Desktop bool
-	Mobile  bool
-	Tablet  bool
-	TV      bool
-	Bot     bool
 }
 
 var resultCases = []ResultCase{
 	// Windows (7)
-	{Browser: internal.Chrome, OS: internal.Windows, Desktop: true, Version: "118.0.0.0"},
-	{Browser: internal.Chrome, OS: internal.Windows, Desktop: true, Version: "59.0.3071.115"},
-	{Browser: internal.IE, OS: internal.Windows, Desktop: true, Version: "8.0"},
-	{Browser: internal.IE, OS: internal.Windows, Desktop: true, Version: "10.0"},
+	{Browser: agents.BrowserChrome, OS: agents.OSWindows, Device: agents.DeviceDesktop, Version: "118.0.0.0"},
+	{Browser: agents.BrowserChrome, OS: agents.OSWindows, Device: agents.DeviceDesktop, Version: "59.0.3071.115"},
+	{Browser: agents.BrowserIE, OS: agents.OSWindows, Device: agents.DeviceDesktop, Version: "8.0"},
+	{Browser: agents.BrowserIE, OS: agents.OSWindows, Device: agents.DeviceDesktop, Version: "10.0"},
 	// Technically should be 11.0, but we need to manually map this after getting it.
-	{Browser: internal.IE, OS: internal.Windows, Desktop: true, Version: "7.0"},
-	{Browser: internal.IE, OS: internal.Windows, Desktop: true, Version: "6.0"},
-	{Browser: internal.Edge, OS: internal.Windows, Desktop: true, Version: "15.15063"},
+	{Browser: agents.BrowserIE, OS: agents.OSWindows, Device: agents.DeviceDesktop, Version: "7.0"},
+	{Browser: agents.BrowserIE, OS: agents.OSWindows, Device: agents.DeviceDesktop, Version: "6.0"},
+	{Browser: agents.BrowserEdge, OS: agents.OSWindows, Device: agents.DeviceDesktop, Version: "15.15063"},
 	// Mac (5) 7
-	{Browser: internal.Safari, OS: internal.MacOS, Desktop: true, Version: "10.1.2"},
-	{Browser: internal.Chrome, OS: internal.MacOS, Desktop: true, Version: "60.0.3112.90"},
-	{Browser: internal.Firefox, OS: internal.MacOS, Desktop: true, Version: "54.0"},
-	{Browser: internal.Vivaldi, OS: internal.MacOS, Desktop: true, Version: "1.92.917.39"},
-	{Browser: internal.Edge, OS: internal.MacOS, Desktop: true, Version: "79.0.309.71"},
+	{Browser: agents.BrowserSafari, OS: agents.OSMacOS, Device: agents.DeviceDesktop, Version: "10.1.2"},
+	{Browser: agents.BrowserChrome, OS: agents.OSMacOS, Device: agents.DeviceDesktop, Version: "60.0.3112.90"},
+	{Browser: agents.BrowserFirefox, OS: agents.OSMacOS, Device: agents.DeviceDesktop, Version: "54.0"},
+	{Browser: agents.BrowserVivaldi, OS: agents.OSMacOS, Device: agents.DeviceDesktop, Version: "1.92.917.39"},
+	{Browser: agents.BrowserEdge, OS: agents.OSMacOS, Device: agents.DeviceDesktop, Version: "79.0.309.71"},
 	// Linux (5) 12
-	{Browser: internal.Firefox, OS: internal.Linux, Desktop: true, Version: "52.0"},
-	{Browser: internal.Firefox, OS: internal.Linux, Desktop: true, Version: "119.0"},
-	{Browser: internal.Firefox, OS: internal.Linux, Desktop: true, Version: "119.0"},
-	{Browser: internal.Firefox, OS: internal.Linux, Desktop: true, Version: "119.0"},
-	{Browser: internal.Chrome, OS: internal.Linux, Desktop: true, Version: "119.0.0.0"},
+	{Browser: agents.BrowserFirefox, OS: agents.OSLinux, Device: agents.DeviceDesktop, Version: "52.0"},
+	{Browser: agents.BrowserFirefox, OS: agents.OSLinux, Device: agents.DeviceDesktop, Version: "119.0"},
+	{Browser: agents.BrowserFirefox, OS: agents.OSLinux, Device: agents.DeviceDesktop, Version: "119.0"},
+	{Browser: agents.BrowserFirefox, OS: agents.OSLinux, Device: agents.DeviceDesktop, Version: "119.0"},
+	{Browser: agents.BrowserChrome, OS: agents.OSLinux, Device: agents.DeviceDesktop, Version: "119.0.0.0"},
 	// iPhone (5) 17
-	{Browser: internal.Safari, OS: internal.IOS, Mobile: true, Version: "10.0"},
-	{Browser: internal.Chrome, OS: internal.IOS, Mobile: true, Version: "60.0.3112.89"},
-	{Browser: internal.Opera, OS: internal.IOS, Mobile: true, Version: "14.0.0.104835"},
-	{Browser: internal.Firefox, OS: internal.IOS, Mobile: true, Version: "8.1.1"},
-	{Browser: internal.Edge, OS: internal.IOS, Mobile: true, Version: "44.11.15"},
+	{Browser: agents.BrowserSafari, OS: agents.OSIOS, Device: agents.DeviceMobile, Version: "10.0"},
+	{Browser: agents.BrowserChrome, OS: agents.OSIOS, Device: agents.DeviceMobile, Version: "60.0.3112.89"},
+	{Browser: agents.BrowserOpera, OS: agents.OSIOS, Device: agents.DeviceMobile, Version: "14.0.0.104835"},
+	{Browser: agents.BrowserFirefox, OS: agents.OSIOS, Device: agents.DeviceMobile, Version: "8.1.1"},
+	{Browser: agents.BrowserEdge, OS: agents.OSIOS, Device: agents.DeviceMobile, Version: "44.11.15"},
 	// iPad (3) 22
-	{Browser: internal.Safari, OS: internal.IOS, Tablet: true, Version: "10.0"},
-	{Browser: internal.Chrome, OS: internal.IOS, Tablet: true, Version: "119.0.6045.169"},
-	{Browser: internal.Firefox, OS: internal.IOS, Tablet: true, Version: "119.0"},
+	{Browser: agents.BrowserSafari, OS: agents.OSIOS, Device: agents.DeviceTablet, Version: "10.0"},
+	{Browser: agents.BrowserChrome, OS: agents.OSIOS, Device: agents.DeviceTablet, Version: "119.0.6045.169"},
+	{Browser: agents.BrowserFirefox, OS: agents.OSIOS, Device: agents.DeviceTablet, Version: "119.0"},
 	// Android (4) 25
-	{Browser: internal.Samsung, OS: internal.Android, Mobile: true, Version: "4.0"},
-	{Browser: internal.AndroidBrowser, OS: internal.Android, Mobile: true, Version: "4.0"},
-	{Browser: internal.AndroidBrowser, OS: internal.Android, Mobile: true, Version: "4.0"},
-	{Browser: internal.Chrome, OS: internal.Android, Mobile: true, Version: "38.0.2125.102"},
-	{Browser: internal.Chrome, OS: internal.Android, Mobile: true, Version: "112.0.0.0"},
+	{Browser: agents.BrowserSamsung, OS: agents.OSAndroid, Device: agents.DeviceMobile, Version: "4.0"},
+	{Browser: agents.BrowserAndroid, OS: agents.OSAndroid, Device: agents.DeviceMobile, Version: "4.0"},
+	{Browser: agents.BrowserAndroid, OS: agents.OSAndroid, Device: agents.DeviceMobile, Version: "4.0"},
+	{Browser: agents.BrowserChrome, OS: agents.OSAndroid, Device: agents.DeviceMobile, Version: "38.0.2125.102"},
+	{Browser: agents.BrowserChrome, OS: agents.OSAndroid, Device: agents.DeviceMobile, Version: "112.0.0.0"},
 	// Bots (6) 29
-	{Bot: true},
-	{Bot: true},
-	{Bot: true},
-	{Bot: true},
-	{Bot: true, Browser: internal.Chrome, Version: "112.0.0.0"},
-	{Bot: true, Browser: internal.Chrome, OS: internal.Linux, Version: "125.0.6422.76"},
+	{Device: agents.DeviceBot},
+	{Device: agents.DeviceBot},
+	{Device: agents.DeviceBot},
+	{Device: agents.DeviceBot},
+	{Device: agents.DeviceBot, Browser: agents.BrowserChrome, Version: "112.0.0.0"},
+	{Device: agents.DeviceBot, Browser: agents.BrowserChrome, OS: agents.OSLinux, Version: "125.0.6422.76"},
 	// Yandex Browser (1) 35
-	{Browser: internal.YandexBrowser, OS: internal.Android, Mobile: true, Version: "24.1.7.27.00"},
+	{Browser: agents.BrowserYandex, OS: agents.OSAndroid, Device: agents.DeviceMobile, Version: "24.1.7.27.00"},
 	// Safari UIWebView (1) 36
-	{Browser: internal.Safari, OS: internal.IOS, Mobile: true},
+	{Browser: agents.BrowserSafari, OS: agents.OSIOS, Device: agents.DeviceMobile},
 	// Falkon (1) 37
-	{Browser: internal.Falkon, OS: internal.Linux, Desktop: true, Version: "24.02.2"},
+	{Browser: agents.BrowserFalkon, OS: agents.OSLinux, Device: agents.DeviceDesktop, Version: "24.02.2"},
 	// Android Firefox (1) 38
-	{Browser: internal.Firefox, OS: internal.Android, Mobile: true, Version: "123.0"},
+	{Browser: agents.BrowserFirefox, OS: agents.OSAndroid, Device: agents.DeviceMobile, Version: "123.0"},
 	// Linux ARM Architecture (1) 39
-	{Browser: internal.Chrome, OS: internal.Linux, Desktop: true, Version: "88.0.4324.182"},
+	{Browser: agents.BrowserChrome, OS: agents.OSLinux, Device: agents.DeviceDesktop, Version: "88.0.4324.182"},
 	// Samsung
-	{Browser: internal.Samsung, OS: internal.Linux, TV: true, Version: "2.1"},
-	{Browser: internal.Samsung, OS: internal.Linux, Desktop: true, Version: "26.0"},
+	{Browser: agents.BrowserSamsung, OS: agents.OSLinux, Device: agents.DeviceTV, Version: "2.1"},
+	{Browser: agents.BrowserSamsung, OS: agents.OSLinux, Device: agents.DeviceDesktop, Version: "26.0"},
 	// OpenBSD (1)
-	{Browser: internal.Firefox, OS: internal.OpenBSD, Desktop: true, Version: "57.0"},
+	{Browser: agents.BrowserFirefox, OS: agents.OSOpenBSD, Device: agents.DeviceDesktop, Version: "57.0"},
 }
 
 func TestParse(t *testing.T) {
@@ -91,14 +86,10 @@ func TestParse(t *testing.T) {
 	for i, v := range testdata.TestCases {
 		t.Run(fmt.Sprintf("Case:%d", i), func(t *testing.T) {
 			result := parser.Parse(v)
-			assert.Equal(t, resultCases[i].Browser, result.GetBrowser(), "Browser\nTest Case: %s\nExpected: %s", v, resultCases[i].Browser)
-			assert.Equal(t, resultCases[i].OS, result.GetOS(), "OS\nTest Case: %s\nExpected: %s", v, resultCases[i].OS)
-			assert.Equal(t, resultCases[i].Desktop, result.IsDesktop(), "Desktop\nTest Case: %s\nExpected: %s", v, resultCases[i].Desktop)
-			assert.Equal(t, resultCases[i].Version, result.GetVersion(), "Version\nTest Case: %s\nExpected: %s", v, resultCases[i].Version)
-			assert.Equal(t, resultCases[i].Mobile, result.IsMobile(), "Mobile\nTest Case: %s\nExpected: %s", v, resultCases[i].Mobile)
-			assert.Equal(t, resultCases[i].Tablet, result.IsTablet(), "Tablet\nTest Case: %s\nExpected: %s", v, resultCases[i].Tablet)
-			assert.Equal(t, resultCases[i].TV, result.IsTV(), "TV\nTest Case: %s\nExpected: %s", v, resultCases[i].TV)
-			assert.Equal(t, resultCases[i].Bot, result.IsBot(), "Bot\nTest Case: %s\nExpected: %s", v, resultCases[i].Bot)
+			assert.Equal(t, resultCases[i].Browser, result.Browser(), "Browser\nTest Case: %s\nExpected: %s", v, resultCases[i].Browser)
+			assert.Equal(t, resultCases[i].OS, result.OS(), "OS\nTest Case: %s\nExpected: %s", v, resultCases[i].OS)
+			assert.Equal(t, resultCases[i].Device, result.Device(), "Device\nTest Case: %s\nExpected: %s", v, resultCases[i].Device)
+			assert.Equal(t, resultCases[i].Version, result.BrowserVersion(), "Browser Version\nTest Case: %s\nExpected: %s", v, resultCases[i].Version)
 		})
 	}
 }


### PR DESCRIPTION
## Overview

This exposes all the user agent string consts in a new `go-useragent/agents` sub-directory which can be referenced by consumers.

The trie structure was also refactored to store matched tokens as `uint8` instead of strings, which should help reduce idle memory consumption a little bit.

## New

A couple new methods have introduced on the `UserAgent` type:

- `Browser()` returns new `Browser` string alias (`GetBrowser()` has been deprecated)
- `OS()` returns new `OS` string alias (`GetOS()` has been deprecated)
- `Device()` returns a new `Device` string alias (`GetDevice()` has been deprecated)
- `BrowserVersion()` returns browser version (`GetVersion()` has been deprecated as we prepare for OS versions)

- `BrowserVersionMajor()` returns major browser version (`GetMajorVersion()` has been deprecated as we prepare for OS versions)
- `BrowserVersionMinor()`
- `BrowserVersionPatch()`


