### PR TITLE
fix(agents): read IE 11 version from rv instead of Trident

### DIFF
--- a/data/cases.go
+++ b/data/cases.go
@@ -67,7 +67,17 @@ var AllTestCases = []UATestCase{
 		ExpectedBrowser:      agents.BrowserIE,
 		ExpectedOS:           agents.OSWindows,
 		ExpectedDevice:       agents.DeviceDesktop,
-		ExpectedVersion:      "7.0",
+		ExpectedVersion:      "11.0",
+	},
+	{
+		Name:                 "Windows IE 11 (WOW64)",
+		UserAgent:            "Mozilla/5.0 (Windows NT 6.1; WOW64; Trident/7.0; rv:11.0) like Gecko",
+		ExpectedMatches:      []internal.Match{internal.BrowserIE, internal.OSWindows},
+		ExpectedCleanVersion: "MozillaWindowsNTWOWTridentrvlikeGecko",
+		ExpectedBrowser:      agents.BrowserIE,
+		ExpectedOS:           agents.OSWindows,
+		ExpectedDevice:       agents.DeviceDesktop,
+		ExpectedVersion:      "11.0",
 	},
 	{
 		Name:                 "Windows IE 6",

--- a/trie.go
+++ b/trie.go
@@ -3,6 +3,7 @@ package useragent
 import (
 	"math"
 	"slices"
+	"strings"
 	"unsafe"
 
 	"github.com/medama-io/go-useragent/internal"
@@ -180,7 +181,40 @@ func (trie *RuneTrie) Get(key string) UserAgent {
 		}
 	}
 
+	// IE 11 dropped the "MSIE" token, so it matches via "Trident" and the walk
+	// captured the Trident engine version. The real version is in "rv:".
+	if ua.browser == internal.BrowserIE {
+		ua.applyRVVersion(key)
+	}
+
 	return ua
+}
+
+// applyRVVersion overwrites the version with the number after "rv:", if present.
+// Used for IE 11, which reports its version there rather than after Trident.
+func (ua *UserAgent) applyRVVersion(key string) {
+	idx := strings.Index(key, "rv:")
+	if idx < 0 {
+		return
+	}
+
+	var buf [32]rune
+	n := 0
+	for i := idx + 3; i < len(key) && n < len(buf); i++ {
+		c := rune(key[i])
+		if !internal.IsDigit(c) && c != '.' {
+			break
+		}
+		buf[n] = c
+		n++
+	}
+
+	if n == 0 {
+		return
+	}
+
+	ua.version = buf
+	ua.versionIndex = n
 }
 
 // Put inserts the value into the trie at the given key, replacing any


### PR DESCRIPTION
Closes #83 

IE 11 was detected as IE, but with version 7.0 instead of 11.0.

The fix reads the version from rv: when the browser is IE. Older IE (6–10) still carry MSIE x.0 and have no rv:, so they're untouched.