### PR TITLE
perf: store version buffer as bytes instead of runes

### DIFF
--- a/trie.go
+++ b/trie.go
@@ -94,9 +94,9 @@ func (trie *RuneTrie) Get(key string) UserAgent {
 			if !internal.IsDigit(r) && r != '.' {
 				state = stateDefault
 			} else {
-				// Add to rune buffer.
+				// Add to version buffer. Versions are ASCII, so store as bytes.
 				if ua.versionIndex < cap(ua.version) {
-					ua.version[ua.versionIndex] = r
+					ua.version[ua.versionIndex] = byte(r)
 					ua.versionIndex++
 				}
 			}
@@ -139,7 +139,7 @@ func (trie *RuneTrie) Get(key string) UserAgent {
 						ua.versionIndex == 0) {
 					// Clear version buffer if it has old values.
 					if ua.versionIndex > 0 {
-						ua.version = [32]rune{}
+						ua.version = [32]byte{}
 						ua.versionIndex = 0
 					}
 

--- a/ua.go
+++ b/ua.go
@@ -25,7 +25,7 @@ type Parser struct {
 }
 
 type UserAgent struct {
-	version      [32]rune
+	version      [32]byte
 	versionIndex int
 
 	browser internal.Match


### PR DESCRIPTION
This is a very minor performance improvement.

UserAgent held its version in a [32]rune buffer. Versions are only ever ASCII so a rune is overkill. Switching to [32]byte shrinks the struct from 144 to 48 bytes, which cuts the copy cost since Parse returns UserAgent by value.